### PR TITLE
Update imageasset for master Vich

### DIFF
--- a/Twig/Extension/ImageAssetsExtension.php
+++ b/Twig/Extension/ImageAssetsExtension.php
@@ -60,6 +60,9 @@ class ImageAssetsExtension extends \Twig_Extension
                 $this->container->get('vich_uploader.templating.helper.uploader_helper')  
             );
             
+            // Overwrite the fieldname with the needed mapping by Vich
+            $params[1] = $this->container->get('vich_uploader.property_mapping_factory')->fromField($object, $field)->getMappingName();
+            
             return call_user_func_array(array($ext, "asset"), $params);
         }
         


### PR DESCRIPTION
As from dd408d in the master of Vich Uploader Bundle, the field name in
asset is changed to mappingName. See
https://github.com/dustin10/VichUploaderBundle/commit/dd408d554ec97ed8afcbd6ce96201982d04a5b03.
