### PR TITLE
Only reset the image, not the complete form

### DIFF
--- a/Resources/views/Form/SingleUpload/controls.html.twig
+++ b/Resources/views/Form/SingleUpload/controls.html.twig
@@ -1,6 +1,6 @@
 <div class="singleupload-controls-wrapper">
     <div class="btn-wrapper">
-        <button type="reset" class="btn btn-warning cancel" style="display: none;">
+        <button type="button" class="btn btn-warning cancel" style="display: none;">
             <i class="fa fa-ban"></i>
             <span> {{ 's2a_single_upload.button.cancel'|trans({}, 'AdmingeneratorFormExtensions') }}</span>
         </button>


### PR DESCRIPTION
See https://github.com/symfony2admingenerator/AvocodeFormExtensionsBundle/pull/150, same PR, but then for the new-unstable.
