### PR TITLE
[s2a_date_picker] Fix for empty date values

### DIFF
--- a/Resources/views/Form/form_js.html.twig
+++ b/Resources/views/Form/form_js.html.twig
@@ -353,11 +353,14 @@
     $widget.datetimepicker(config);
 {% if widget_value is defined %}
     $widget.data("DateTimePicker").setDate(moment("{{ widget_value }}", "{{ widget_format }}"));
+{% else %}
+    $widget.data("DateTimePicker").setValue(null);    
 {% endif %}
 
     var copyValue = function() {
         var date = $widget.data("DateTimePicker").getDate();
-        $field.val(moment(date).format("{{ widget_format }}"));
+        if(date == null) $field.val('')
+        else $field.val(moment(date).format("{{ widget_format }}"));
     };
 
     $widget.on("dp.change", copyValue);


### PR DESCRIPTION
Fix javascript code to correctly handle situation with empty fields.
Without this patch when you create a new object with s2a_date_picker field
on form submit javascript code always set value of field to the current day.
