### PR TITLE
Fixes unknown variable 'width' in Date/TimePicker formtypes

### DIFF
--- a/Form/Type/DatePickerType.php
+++ b/Form/Type/DatePickerType.php
@@ -20,6 +20,7 @@ class DatePickerType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
+        $view->vars['width'] = $options['width'];
         $view->vars['config'] = array_replace($options['config'], array(
             'pickDate'  => true,
             'pickTime'  => false
@@ -40,6 +41,7 @@ class DatePickerType extends AbstractType
         $resolver->setDefaults(array(
             'widget'    => 'single_text',
             'format'    => 'yyyy-MM-dd',
+            'width'     => null,
             'config'    => array(
                 'pickDate'  => true,
                 'pickTime'  => false,
@@ -53,6 +55,7 @@ class DatePickerType extends AbstractType
         ));
 
         $resolver->setAllowedTypes(array(
+            'width'  => array('null', 'integer'),
             'config' => array('array')
         ));
 

--- a/Form/Type/TimePickerType.php
+++ b/Form/Type/TimePickerType.php
@@ -20,6 +20,7 @@ class TimePickerType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
+        $view->vars['width'] = $options['width'];
         $view->vars['config'] = array_replace($options['config'], array(
             'pickDate'      => false,
             'pickTime'      => true,
@@ -50,6 +51,7 @@ class TimePickerType extends AbstractType
     {
         $resolver->setDefaults(array(
             'widget'        => 'single_text',
+            'width'     => null,
             'config'        => array(
                 'pickDate'      => false,
                 'pickTime'      => true,
@@ -63,6 +65,7 @@ class TimePickerType extends AbstractType
         ));
 
         $resolver->setAllowedTypes(array(
+            'width'  => array('null', 'integer'),
             'config' => array('array')
         ));
 


### PR DESCRIPTION
The changes as done in a1f116ed335e047206e7c4ce26bd32502e6468d2, but now also for the Date and Time types, as they share the same twig prototype. 