### PR TITLE
Add a way to disable select form extension

### DIFF
--- a/Form/Extension/BootstrapSelectExtension.php
+++ b/Form/Extension/BootstrapSelectExtension.php
@@ -13,7 +13,7 @@ class BootstrapSelectExtension extends AbstractTypeExtension
 {
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        if (false === $options['expanded']) {
+        if (false === $options['expanded'] && !array_key_exists('class', $options['attr'])) {
             $view->vars['attr'] = array_merge($view->vars['attr'], array(
                 'class' => 'selectpicker'
             ));

--- a/Resources/doc/documentation.md
+++ b/Resources/doc/documentation.md
@@ -48,3 +48,4 @@
 * AutocompleteExtension [documentation](autocomplete-extension/overview.md)
 * HelpMessageExtension [documentation](help-message-extension/overview.md)
 * NovalidateExtension [documentation](novalidate-extension/overview.md)
+* SelectExtension [documentation](select-extension/overview.md)

--- a/Resources/doc/select-extension/overview.md
+++ b/Resources/doc/select-extension/overview.md
@@ -1,0 +1,15 @@
+# Select extension
+---------------------------------------
+
+[go back to Table of contents][back-to-index]
+
+[back-to-index]: https://github.com/symfony2admingenerator/FormExtensionsBundle/blob/master/Resources/doc/documentation.md
+
+### Description
+
+Select extension enhances visually choice field, when it would be rendered as a select tag. 
+The select tag is hidden, and in it's place a bootstrap-styled dropdown list is shown.
+
+> **Note:** if `attr -> class` is explicicly set, the extension will be disabled. 
+> If for some reason you need to add custom classes, but you would like to keep the extension enabled,
+> add the `selectpicker` class aswell.

--- a/Resources/views/Form/form_js.html.twig
+++ b/Resources/views/Form/form_js.html.twig
@@ -334,7 +334,9 @@
 
     {% block choice_js_prototype %}
         {% if not expanded %}
-        $field.selectpicker();
+        if ($field.hasClass("selectpicker")) {
+            $field.selectpicker();
+        }
         {% endif %}
     {% endblock choice_js_prototype %}
     });


### PR DESCRIPTION
Use form extension for expanded choice fields unless class is explicitly set.