### PR TITLE
Prefixed class, to avoid conflict with bootstrap styles.

### DIFF
--- a/Resources/views/Form/form_html.html.twig
+++ b/Resources/views/Form/form_html.html.twig
@@ -1,6 +1,6 @@
 {% block form_row %}
 {% spaceless %}
-    <div class="control-group {{ name }}{% if errors|length > 0 %} has-error{% endif %}">
+    <div class="control-group control-group-{{ name }}{% if errors|length > 0 %} has-error{% endif %}">
         {{ form_label(form) }}
         {{ form_widget(form) }}
         {% if not compound %}


### PR DESCRIPTION
This PR solve the problem if the name of the property is the same as some class is bootstrap. For example if you have a lead property, this div is than styled like lead of bootstrap.