### PR TITLE
Remove deprecated calls for Symfony 2.7

### DIFF
--- a/EventListener/CollectionUploadListener.php
+++ b/EventListener/CollectionUploadListener.php
@@ -5,7 +5,6 @@ use Admingenerator\FormExtensionsBundle\Storage\FileStorageInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -37,9 +36,9 @@ class CollectionUploadListener implements EventSubscriberInterface
     protected $propertyAccessor;
 
     /**
-     * @param SessionInterface $session
-     * @param Request $request
-     * @param string $routeName
+     * @param FileStorageInterface      $storage
+     * @param string                    $routeName
+     * @param PropertyAccessorInterface $propertyAccessor
      */
     public function __construct(FileStorageInterface $storage, $routeName, PropertyAccessorInterface $propertyAccessor)
     {

--- a/Form/EventListener/SingleUploadSubscriber.php
+++ b/Form/EventListener/SingleUploadSubscriber.php
@@ -14,7 +14,7 @@ use Vich\UploaderBundle\Event\Events;
 class SingleUploadSubscriber implements EventSubscriberInterface
 {
     /**
-     * @var string Single upload field configs
+     * @var array Single upload field configs
      */
     protected $configs = array();
     

--- a/Form/Extension/AutocompleteExtension.php
+++ b/Form/Extension/AutocompleteExtension.php
@@ -5,7 +5,7 @@ namespace Admingenerator\FormExtensionsBundle\Form\Extension;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author havvg <tuebernickel@gmail.com>
@@ -28,15 +28,15 @@ class AutocompleteExtension extends AbstractTypeExtension
         }
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'autocomplete' => true,
         ));
         
-        $resolver->setAllowedTypes(array(
-            'autocomplete' => array('bool'),
-        ));
+        $resolver->setAllowedTypes(
+            'autocomplete', array('bool')
+        );
     }
 
     public function getExtendedType()

--- a/Form/Extension/HelpMessageExtension.php
+++ b/Form/Extension/HelpMessageExtension.php
@@ -6,7 +6,7 @@ use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author havvg <tuebernickel@gmail.com>
@@ -24,15 +24,15 @@ class HelpMessageExtension extends AbstractTypeExtension
         $view->vars['help'] = $form->getConfig()->getAttribute('help');
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'help' => null,
         ));
         
-        $resolver->setAllowedTypes(array(
-            'help' => array('null', 'string')
-        ));
+        $resolver->setAllowedTypes(
+            'help', array('null', 'string')
+        );
     }
 
     public function getExtendedType()

--- a/Form/Extension/NoValidateExtension.php
+++ b/Form/Extension/NoValidateExtension.php
@@ -6,6 +6,7 @@ use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -26,15 +27,15 @@ class NoValidateExtension extends AbstractTypeExtension
         }
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'novalidate' => false,
         ));
         
-        $resolver->setAllowedTypes(array(
-            'novalidate' => array('bool'),
-        ));
+        $resolver->setAllowedTypes(
+            'novalidate', array('bool')
+        );
     }
 
     public function getExtendedType()

--- a/Form/Model/UploadCollectionFileInterface.php
+++ b/Form/Model/UploadCollectionFileInterface.php
@@ -33,7 +33,7 @@ interface UploadCollectionFileInterface
     /**
      * Get file
      *
-     * @return Symfony\Component\HttpFoundation\File\File
+     * @return \Symfony\Component\HttpFoundation\File\File
      */
     public function getFile();
 

--- a/Form/Type/BootstrapCollectionType.php
+++ b/Form/Type/BootstrapCollectionType.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * See `Resources/doc/bootstrap-collection/overview.md` for documentation
@@ -45,7 +45,7 @@ class BootstrapCollectionType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'sortable'          => false,
@@ -54,12 +54,15 @@ class BootstrapCollectionType extends AbstractType
             'fieldset_class'    => 'col-md-4',
         ));
 
-        $resolver->setAllowedTypes(array(
-            'sortable'        => array('bool'),
-            'sortable_field'  => array('string'),
-            'new_label'       => array('string'),
-            'fieldset_class'  => array('string'),
-        ));
+        $resolver->setAllowedTypes(
+            'sortable', array('bool')
+        )->setAllowedTypes(
+            'sortable_field', array('string')
+        )->setAllowedTypes(
+            'new_label', array('string')
+        )->setAllowedTypes(
+            'fieldset_class', array('string')
+        );
     }
 
     /**

--- a/Form/Type/CollectionUploadType.php
+++ b/Form/Type/CollectionUploadType.php
@@ -4,12 +4,11 @@ namespace Admingenerator\FormExtensionsBundle\Form\Type;
 
 use Admingenerator\FormExtensionsBundle\Form\EventListener\CollectionUploadSubscriber;
 use Admingenerator\FormExtensionsBundle\Storage\FileStorageInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
@@ -25,7 +24,7 @@ class CollectionUploadType extends AbstractType
     protected $storage = null;
 
     /**
-     * @param FileStorageInterface $fileStorage
+     * @param FileStorageInterface $storage
      */
     public function setFileStorage(FileStorageInterface $storage)
     {
@@ -92,9 +91,9 @@ class CollectionUploadType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
-        parent::setDefaultOptions($resolver);
+        parent::configureOptions($resolver);
 
         $resolver->setDefaults(array(
             'acceptFileTypes'           => '/.*$/i',
@@ -127,41 +126,69 @@ class CollectionUploadType extends AbstractType
 
         // This seems weird... why to we accept it as option if we force
         // its value?
-        $resolver->setAllowedValues(array(
-            'novalidate'  => array(true),
-            'multipart'   => array(true),
-            'multiple'    => array(true),
-            'required'    => array(false),
-        ));
+        $resolver->setAllowedValues(
+            'novalidate', array(true)
+        )->setAllowedValues(
+            'multipart', array(true)
+        )->addAllowedValues(
+            'multiple', array(true)
+        )->setAllowedValues(
+            'required', array(false)
+        );
 
-        $resolver->setAllowedTypes(array(
-            'acceptFileTypes'           => array('string'),
-            'autoUpload'                => array('bool'),
-            'editable'                  => array('array'),
-            'displayDownloadButton'     => array('bool'),
-            'loadImageFileTypes'        => array('string'),
-            'loadImageMaxFileSize'      => array('integer'),
-            'maxNumberOfFiles'          => array('integer', 'null'),
-            'maxFileSize'               => array('integer', 'null'),
-            'minFileSize'               => array('integer', 'null'),
-            'multipart'                 => array('bool'),
-            'multiple'                  => array('bool'),
-            'nameable'                  => array('bool'),
-            'nameable_field'            => array('string', 'null'),
-            'novalidate'                => array('bool'),
-            'prependFiles'              => array('bool'),
-            'previewAsCanvas'           => array('bool'),
-            'previewFilter'             => array('string', 'null'),
-            'itemFilter'                => array('string', 'null'),
-            'previewMaxWidth'           => array('integer'),
-            'previewMaxHeight'          => array('integer'),
-            'primary_key'               => array('string'),
-            'required'                  => array('bool'),
-            'sortable'                  => array('bool'),
-            'sortable_field'            => array('string'),
-            'uploadRouteName'           => array('string', 'null'),
-            'uploadRouteParameters'     => array('array')
-        ));
+        $resolver->setAllowedTypes(
+            'acceptFileTypes', array('string')
+        )->setAllowedTypes(
+            'autoUpload', array('bool')
+        )->setAllowedTypes(
+            'editable', array('array')
+        )->setAllowedTypes(
+            'displayDownloadButton', array('bool')
+        )->setAllowedTypes(
+            'loadImageFileTypes', array('string')
+        )->setAllowedTypes(
+            'loadImageMaxFileSize', array('integer')
+        )->setAllowedTypes(
+            'maxNumberOfFiles', array('integer', 'null')
+        )->setAllowedTypes(
+            'maxFileSize', array('integer', 'null')
+        )->setAllowedTypes(
+            'minFileSize', array('integer', 'null')
+        )->setAllowedTypes(
+            'multipart', array('bool')
+        )->setAllowedTypes(
+            'multiple', array('bool')
+        )->setAllowedTypes(
+            'nameable', array('bool')
+        )->setAllowedTypes(
+            'nameable_field', array('string', 'null')
+        )->setAllowedTypes(
+            'novalidate' , array('bool')
+        )->setAllowedTypes(
+            'prependFiles', array('bool')
+        )->setAllowedTypes(
+            'previewAsCanvas', array('bool')
+        )->setAllowedTypes(
+            'previewFilter', array('string', 'null')
+        )->setAllowedTypes(
+            'itemFilter', array('string', 'null')
+        )->setAllowedTypes(
+            'previewMaxWidth', array('integer')
+        )->setAllowedTypes(
+            'previewMaxHeight', array('integer')
+        )->setAllowedTypes(
+            'primary_key', array('string')
+        )->setAllowedTypes(
+            'required', array('bool')
+        )->setAllowedTypes(
+            'sortable', array('bool')
+        )->setAllowedTypes(
+            'sortable_field', array('string')
+        )->setAllowedTypes(
+            'uploadRouteName', array('string', 'null')
+        )->setAllowedTypes(
+            'uploadRouteParameters', array('array')
+        );
     }
 
     /**

--- a/Form/Type/DatePickerType.php
+++ b/Form/Type/DatePickerType.php
@@ -3,10 +3,9 @@
 namespace Admingenerator\FormExtensionsBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * See `Resources/doc/bootstrap-datetimepicker/overview.md` for documentation
@@ -33,7 +32,7 @@ class DatePickerType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'widget'    => 'single_text',
@@ -49,15 +48,17 @@ class DatePickerType extends AbstractType
             )
         ));
 
-        $resolver->setAllowedTypes(array(
-            'width'  => array('null', 'integer'),
-            'config' => array('array')
-        ));
+        $resolver->setAllowedTypes(
+            'width', array('null', 'integer')
+        )->setAllowedTypes(
+            'config', array('array')
+        );
 
-        $resolver->setAllowedValues(array(
-            'widget' => array('single_text'),
-            'format' => array('yyyy-MM-dd')
-        ));
+        $resolver->setAllowedValues(
+            'widget', array('single_text')
+        )->setAllowedValues(
+            'format', array('yyyy-MM-dd')
+        );
     }
 
     /**

--- a/Form/Type/DateRangePickerType.php
+++ b/Form/Type/DateRangePickerType.php
@@ -3,12 +3,9 @@
 namespace Admingenerator\FormExtensionsBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\OptionsResolver\Options;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
@@ -66,7 +63,7 @@ class DateRangePickerType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'startDate'             => null,
@@ -124,30 +121,51 @@ class DateRangePickerType extends AbstractType
             'callback'              => 'function(start, end, label) {}'
         ));
         
-        $resolver->setAllowedTypes(array(
-            'startDate'             => array('null', 'string'),
-            'endDate'               => array('null', 'string'),
-            'minDate'               => array('null', 'string'),
-            'maxDate'               => array('null', 'string'),
-            'dateLimit'             => array('null', 'string'),
-            'timeZone'              => array('string'),
-            'showDropdowns'         => array('bool'),
-            'showWeekNumbers'       => array('bool'),
-            'timePicker'            => array('bool'),
-            'timePickerIncrement'   => array('integer'),
-            'timePicker12Hour'      => array('bool'),
-            'timePickerSeconds'     => array('bool'),
-            'ranges'                => array('array'),
-            'buttonClasses'         => array('array'),
-            'applyClass'            => array('string'),
-            'cancelClass'           => array('string'),
-            'format'                => array('string'),
-            'separator'             => array('string'),
-            'locale'                => array('array'),
-            'singleDatePicker'      => array('bool'),
-            'parentEl'              => array('string'),
-            'callback'              => array('string'),
-        ));
+        $resolver->setAllowedTypes(
+            'startDate', array('null', 'string')
+        )->setAllowedTypes(
+            'endDate', array('null', 'string')
+        )->setAllowedTypes(
+            'minDate', array('null', 'string')
+        )->setAllowedTypes(
+            'maxDate', array('null', 'string')
+        )->setAllowedTypes(
+            'dateLimit', array('null', 'string')
+        )->setAllowedTypes(
+            'timeZone', array('string')
+        )->setAllowedTypes(
+            'showDropdowns', array('bool')
+        )->setAllowedTypes(
+            'showWeekNumbers', array('bool')
+        )->setAllowedTypes(
+            'timePicker', array('bool')
+        )->setAllowedTypes(
+            'timePickerIncrement', array('integer')
+        )->setAllowedTypes(
+            'timePicker12Hour', array('bool')
+        )->setAllowedTypes(
+            'timePickerSeconds', array('bool')
+        )->setAllowedTypes(
+            'ranges', array('array')
+        )->setAllowedTypes(
+            'buttonClasses', array('array')
+        )->setAllowedTypes(
+            'applyClass', array('string')
+        )->setAllowedTypes(
+            'cancelClass', array('string')
+        )->setAllowedTypes(
+            'format', array('string')
+        )->setAllowedTypes(
+            'separator', array('string')
+        )->setAllowedTypes(
+            'locale', array('array')
+        )->setAllowedTypes(
+            'singleDatePicker', array('bool')
+        )->setAllowedTypes(
+            'parentEl', array('string')
+        )->setAllowedTypes(
+            'callback', array('string')
+        );
     }
     
     /**

--- a/Form/Type/DateTimePickerType.php
+++ b/Form/Type/DateTimePickerType.php
@@ -5,7 +5,7 @@ namespace Admingenerator\FormExtensionsBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 
 /**
@@ -41,7 +41,7 @@ class DateTimePickerType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'widget'    => 'single_text',
@@ -58,15 +58,17 @@ class DateTimePickerType extends AbstractType
             )
         ));
 
-        $resolver->setAllowedTypes(array(
-            'width'  => array('null', 'integer'),
-            'config' => array('array')
-        ));
+        $resolver->setAllowedTypes(
+            'width', array('null', 'integer')
+        )->setAllowedTypes(
+            'config', array('array')
+        );
 
-        $resolver->setAllowedValues(array(
-            'widget' => array('single_text'),
-            'format' => array(DateTimeType::HTML5_FORMAT)
-        ));
+        $resolver->setAllowedValues(
+            'widget', array('single_text')
+        )->setAllowedValues(
+            'format', array(DateTimeType::HTML5_FORMAT)
+        );
     }
 
     /**

--- a/Form/Type/DoubleListType.php
+++ b/Form/Type/DoubleListType.php
@@ -3,7 +3,7 @@
 namespace Admingenerator\FormExtensionsBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * See `Resources/doc/double-list/overview.md` for documentation
@@ -22,7 +22,7 @@ class DoubleListType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'multiple'    => true,

--- a/Form/Type/GoogleMapType.php
+++ b/Form/Type/GoogleMapType.php
@@ -3,12 +3,10 @@
 namespace Admingenerator\FormExtensionsBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\OptionsResolver\Options;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * See `Resources/doc/google-map/overview.md` for documentation
@@ -31,7 +29,7 @@ class GoogleMapType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'type'           => 'text',

--- a/Form/Type/KnobType.php
+++ b/Form/Type/KnobType.php
@@ -3,7 +3,7 @@
 namespace Admingenerator\FormExtensionsBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 
@@ -53,7 +53,7 @@ class KnobType extends AbstractType
         );
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'width'           => 200,
@@ -74,29 +74,45 @@ class KnobType extends AbstractType
             'hide_box_shadow' => true,
         ));
 
-        $resolver->setAllowedTypes(array(
-            'width'           => array('integer'),
-            'height'          => array('integer'),
-            'displayInput'    => array('bool'),
-            'displayPrevious' => array('bool'),
-            'angleArc'        => array('numeric'),
-            'angleOffset'     => array('numeric'),
-            'cursor'          => array('numeric', 'bool'),
-            'readOnly'        => array('bool'),
-            'thickness'       => array('numeric'),
-            'fgColor'         => array('string'),
-            'bgColor'         => array('string'),
-            'step'            => array('numeric'),
-            'min'             => array('numeric'),
-            'max'             => array('numeric'),
-            'hide_box_shadow' => array('bool'),
-        ));
+        $resolver->setAllowedTypes(
+            'width', array('integer')
+        )->setAllowedTypes(
+            'height', array('integer')
+        )->setAllowedTypes(
+            'displayInput', array('bool')
+        )->setAllowedTypes(
+            'displayPrevious', array('bool')
+        )->setAllowedTypes(
+            'angleArc', array('numeric')
+        )->setAllowedTypes(
+            'angleOffset', array('numeric')
+        )->setAllowedTypes(
+            'cursor', array('numeric', 'bool')
+        )->setAllowedTypes(
+            'readOnly', array('bool')
+        )->setAllowedTypes(
+            'thickness', array('numeric')
+        )->setAllowedTypes(
+            'fgColor', array('string')
+        )->setAllowedTypes(
+            'bgColor', array('string')
+        )->setAllowedTypes(
+            'step', array('numeric')
+        )->setAllowedTypes(
+            'min', array('numeric')
+        )->setAllowedTypes(
+            'max', array('numeric')
+        )->setAllowedTypes(
+            'hide_box_shadow', array('bool')
+        );
 
-        $resolver->setAllowedValues(array(
-            'angleArc'    => range(0, 359),
-            'angleOffset' => range(0, 359),
-            'lineCap'     => array('butt', 'round'),
-        ));
+        $resolver->setAllowedValues(
+            'angleArc', range(0, 359)
+        )->setAllowedValues(
+            'angleOffset', range(0, 359)
+        )->setAllowedValues(
+            'lineCap', array('butt', 'round')
+        );
     }
 
     public function getParent()

--- a/Form/Type/MiniColorsType.php
+++ b/Form/Type/MiniColorsType.php
@@ -5,7 +5,7 @@ namespace Admingenerator\FormExtensionsBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * See `Resources/doc/mini-colors/overview.md` for documentation
@@ -44,7 +44,7 @@ class MiniColorsType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'animationSpeed'  => 100,
@@ -62,24 +62,35 @@ class MiniColorsType extends AbstractType
             'theme'           => 'bootstrap'
         ));
 
-        $resolver->setAllowedValues(array(
-            'control'        => array('hue', 'brightness', 'saturation', 'wheel'),
-            'letterCase'     => array('lowercase', 'uppercase'),
-            'position'       => array('default', 'top', 'left', 'top left'),
-            'swatchPosition' => array('left', 'right')
-        ));
+        $resolver->setAllowedValues(
+            'control', array('hue', 'brightness', 'saturation', 'wheel')
+        )->setAllowedValues(
+            'letterCase', array('lowercase', 'uppercase')
+        )->setAllowedValues(
+            'position', array('default', 'top', 'left', 'top left')
+        )->setAllowedValues(
+            'swatchPosition', array('left', 'right')
+        );
 
-        $resolver->setAllowedTypes(array(
-            'animationSpeed'  => 'integer',
-            'animationEasing' => 'string',
-            'changeDelay'     => 'integer',
-            'hideSpeed'       => 'integer',
-            'inline'          => 'bool',
-            'opacity'         => 'bool',
-            'showSpeed'       => 'integer',
-            'textfield'       => 'bool',
-            'theme'           => 'string'
-        ));
+        $resolver->setAllowedTypes(
+            'animationSpeed',  array('integer')
+        )->setAllowedTypes(
+            'animationEasing', array('string')
+        )->setAllowedTypes(
+            'changeDelay', array('integer')
+        )->setAllowedTypes(
+            'hideSpeed', array('integer')
+        )->setAllowedTypes(
+            'inline', array('bool')
+        )->setAllowedTypes(
+            'opacity', array('bool')
+        )->setAllowedTypes(
+            'showSpeed', array('integer')
+        )->setAllowedTypes(
+            'textfield', array('bool')
+        )->setAllowedTypes(
+            'theme', array('string')
+        );
     }
 
     /**

--- a/Form/Type/Select2Type.php
+++ b/Form/Type/Select2Type.php
@@ -2,12 +2,13 @@
 
 namespace Admingenerator\FormExtensionsBundle\Form\Type;
 
+use Admingenerator\FormExtensionsBundle\Form\DataTransformer\ArrayToStringTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * See `Resources/doc/select2/overview.md` for documentation
@@ -56,7 +57,7 @@ class Select2Type extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $defaults = array(
             'allowClear'         => false,
@@ -70,11 +71,11 @@ class Select2Type extends AbstractType
                 'configs'       => $defaults,
                 'transformer'   => null,
             ))
-            ->setNormalizers(array(
-                'configs' => function (Options $options, $configs) use ($defaults) {
+            ->setNormalizer(
+                'configs', function (Options $options, $configs) use ($defaults) {
                     return array_merge($defaults, $configs);
-                },
-            ))
+                }
+            )
         ;
     }
 

--- a/Form/Type/SingleUploadType.php
+++ b/Form/Type/SingleUploadType.php
@@ -5,7 +5,7 @@ namespace Admingenerator\FormExtensionsBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
@@ -66,9 +66,9 @@ class SingleUploadType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
-        parent::setDefaultOptions($resolver);
+        parent::configureOptions($resolver);
 
         $resolver->setDefaults(array(
             'nameable'          => false,
@@ -86,24 +86,35 @@ class SingleUploadType extends AbstractType
             'required'          => false,
         ));
 
-        $resolver->setAllowedValues(array(
-            'multipart'   => array(true),
-            'novalidate'  => array(true),
-            'required'    => array(false),
-        ));
+        $resolver->setAllowedValues(
+            'multipart', array(true)
+        )->setAllowedValues(
+            'novalidate', array(true)
+        )->setAllowedValues(
+            'required', array(false)
+        );
 
-        $resolver->setAllowedTypes(array(
-            'nameable'          => array('string', 'bool'),
-            'deleteable'        => array('string', 'bool'),
-            'downloadable'      => array('bool'),
-            'maxWidth'          => array('integer'),
-            'maxHeight'         => array('integer'),
-            'minWidth'          => array('integer'),
-            'minHeight'         => array('integer'),
-            'previewImages'     => array('bool'),
-            'previewAsCanvas'   => array('bool'),
-            'previewFilter'     => array('string', 'null'),
-        ));
+        $resolver->setAllowedTypes(
+            'nameable', array('string', 'bool')
+        )->setAllowedTypes(
+            'deleteable', array('string', 'bool')
+        )->setAllowedTypes(
+            'downloadable', array('bool')
+        )->setAllowedTypes(
+            'maxWidth', array('integer')
+        )->setAllowedTypes(
+            'maxHeight', array('integer')
+        )->setAllowedTypes(
+            'minWidth', array('integer')
+        )->setAllowedTypes(
+            'minHeight', array('integer')
+        )->setAllowedTypes(
+            'previewImages', array('bool')
+        )->setAllowedTypes(
+            'previewAsCanvas', array('bool')
+        )->setAllowedTypes(
+            'previewFilter', array('string', 'null')
+        );
     }
 
     /**
@@ -152,12 +163,12 @@ class SingleUploadType extends AbstractType
         return 'unknown';
     }
 
-    private function _isAudio($file)
+    private function _isAudio(File $file)
     {
         return (preg_match('/audio\/.*/i', $file->getMimeType()));
     }
 
-    private function _isArchive($file)
+    private function _isArchive(File $file)
     {
         return (
             preg_match('/application\/.*compress.*/i', $file->getMimeType()) ||
@@ -170,17 +181,17 @@ class SingleUploadType extends AbstractType
         );
     }
 
-    private function _isHTML($file)
+    private function _isHTML(File $file)
     {
         return (preg_match('/text\/html/i', $file->getMimeType()));
     }
 
-    private function _isImage($file)
+    private function _isImage(File $file)
     {
         return (preg_match('/image\/.*/i', $file->getMimeType()));
     }
 
-    private function _isPDFDocument($file)
+    private function _isPDFDocument(File $file)
     {
         return (
             preg_match('/application\/acrobat/i', $file->getMimeType()) ||
@@ -189,12 +200,12 @@ class SingleUploadType extends AbstractType
         );
     }
 
-    private function _isPlainText($file)
+    private function _isPlainText(File $file)
     {
         return (preg_match('/text\/plain/i', $file->getMimeType()));
     }
 
-    private function _isPresentation($file)
+    private function _isPresentation(File $file)
     {
         return (
             preg_match('/application\/.*ms\-powerpoint.*/i', $file->getMimeType()) ||
@@ -203,7 +214,7 @@ class SingleUploadType extends AbstractType
         );
     }
 
-    private function _isSpreadsheet($file)
+    private function _isSpreadsheet(File $file)
     {
         return (
             preg_match('/application\/.*ms\-excel.*/i', $file->getMimeType()) ||
@@ -212,7 +223,7 @@ class SingleUploadType extends AbstractType
         );
     }
 
-    private function _isTextDocument($file)
+    private function _isTextDocument(File $file)
     {
         return (
             preg_match('/application\/.*ms\-?word.*/i', $file->getMimeType()) ||
@@ -221,7 +232,7 @@ class SingleUploadType extends AbstractType
         );
     }
 
-    private function _isVideo($file)
+    private function _isVideo(File $file)
     {
         return (preg_match('/video\/.*/i', $file->getMimeType()));
     }

--- a/Form/Type/TimePickerType.php
+++ b/Form/Type/TimePickerType.php
@@ -3,10 +3,9 @@
 namespace Admingenerator\FormExtensionsBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * See `Resources/doc/bootstrap-datetimepicker/overview.md` for documentation
@@ -42,7 +41,7 @@ class TimePickerType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'widget'        => 'single_text',
@@ -57,14 +56,15 @@ class TimePickerType extends AbstractType
             )
         ));
 
-        $resolver->setAllowedTypes(array(
-            'width'  => array('null', 'integer'),
-            'config' => array('array')
-        ));
+        $resolver->setAllowedTypes(
+            'width', array('null', 'integer')
+        )->setAllowedTypes(
+            'config', array('array')
+        );
 
-        $resolver->setAllowedValues(array(
-            'widget' => array('single_text')
-        ));
+        $resolver->setAllowedValues(
+            'widget', array('single_text')
+        );
     }
 
     /**

--- a/Storage/FileStorageInterface.php
+++ b/Storage/FileStorageInterface.php
@@ -1,6 +1,8 @@
 <?php
 namespace Admingenerator\FormExtensionsBundle\Storage;
 
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
 interface FileStorageInterface
 {
     /**

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "symfony/symfony": ">= 2.2.0",
+        "symfony/symfony": ">= 2.7.0",
         "twig/twig": ">= 1.9.0",
         "twig/extensions": "~1.0",
         "symfony2admingenerator/form-bundle": "~1.0"


### PR DESCRIPTION
In Symfony 2.7, the `setDefaultOptions` method of forms was deprecated in favor of the `configureOptions` method.
This PR fixes that, as well as the deprecation of the possibility to pass arrays of allowed types to `setAllowedTypes` which was deprecated in Symfony 2.6.