### PR TITLE
Remove deprecated classes and calls for Twig 1.12

### DIFF
--- a/Resources/views/Form/form_html.html.twig
+++ b/Resources/views/Form/form_html.html.twig
@@ -277,9 +277,9 @@
             {# ignore these attributes #}
         {%- elseif attrname in ['placeholder', 'title'] -%}
             {{- attrname }}="{{ attrvalue|trans({}, translation_domain) }}"
-        {%- elseif attrvalue is sameas(true) -%}
+        {%- elseif attrvalue is same as(true) -%}
             {{- attrname }}="{{ attrname }}"
-        {%- elseif attrvalue is not sameas(false) -%}
+        {%- elseif attrvalue is not same as(false) -%}
             {{- attrname }}="{{ attrvalue }}"
         {%- endif -%}
     {%- endfor -%}

--- a/Twig/Extension/ImageAssetsExtension.php
+++ b/Twig/Extension/ImageAssetsExtension.php
@@ -32,7 +32,7 @@ class ImageAssetsExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'image_asset'   =>  new \Twig_Function_Method($this, 'asset'),
+            'image_asset'   =>  new \Twig_SimpleFunction('image_asset', array($this, 'asset')),
         );
     }
 
@@ -42,7 +42,7 @@ class ImageAssetsExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'image_filter'  =>  new \Twig_Filter_Method($this, 'filter'),
+            'image_filter'  =>  new \Twig_SimpleFilter('image_filter', array($this, 'filter')),
         );
     }
     

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "symfony/symfony": ">= 2.2.0",
-        "twig/twig": ">= 1.9.0",
+        "twig/twig": ">= 1.12.0",
         "twig/extensions": "~1.0",
         "symfony2admingenerator/form-bundle": "~1.0"
     },


### PR DESCRIPTION
The `Twig_Filter_Method` and `Twig_Function_Method` classes have been deprecated in favor of the `Twig_SimpleFilter` and `Twig_SimpleFunction` classes.
This PR fixes that for this repo.
It also fixes some other deprecated calls.