### PR TITLE
The propel bridge removed from Symfony > 2.7

### DIFF
--- a/Form/Type/DoubleListModelType.php
+++ b/Form/Type/DoubleListModelType.php
@@ -11,6 +11,6 @@ class DoubleListModelType extends DoubleListType
 {
     public function __construct()
     {
-        parent::__construct('model', 'Symfony\Bridge\Propel1\Form\Type\ModelType');
+        parent::__construct('model', 'Propel\Bundle\PropelBundle\Form\Type\ModelType');
     }
 }

--- a/Form/Type/Select2ModelType.php
+++ b/Form/Type/Select2ModelType.php
@@ -11,6 +11,6 @@ class Select2ModelType extends Select2Type
 {
     public function __construct()
     {
-        parent::__construct('model', 'Symfony\Bridge\Propel1\Form\Type\ModelType');
+        parent::__construct('model', 'Propel\Bundle\PropelBundle\Form\Type\ModelType');
     }
 }


### PR DESCRIPTION
As the propel bridge was removed in symfony version >2.7 so we have to point to the PropeBundle.
Using propel in symfony, people add the PropelBundle so there shouldn't be any problem with existing projects and it concerns only persons who use propel