### PR TITLE
Fix return type of getExtendedTypes functions

### DIFF
--- a/Form/Extension/AutocompleteExtension.php
+++ b/Form/Extension/AutocompleteExtension.php
@@ -44,7 +44,7 @@ class AutocompleteExtension extends AbstractTypeExtension
         return self::getExtendedTypes()[0];
     }
 
-    public static function getExtendedTypes()
+    public static function getExtendedTypes(): iterable
     {
         return ['Symfony\Component\Form\Extension\Core\Type\FormType'];
     }

--- a/Form/Extension/BootstrapSelectExtension.php
+++ b/Form/Extension/BootstrapSelectExtension.php
@@ -25,7 +25,7 @@ class BootstrapSelectExtension extends AbstractTypeExtension
         return self::getExtendedTypes()[0];
     }
 
-    public static function getExtendedTypes()
+    public static function getExtendedTypes(): iterable
     {
         return ['Symfony\Component\Form\Extension\Core\Type\ChoiceType'];
     }

--- a/Form/Extension/HelpMessageExtension.php
+++ b/Form/Extension/HelpMessageExtension.php
@@ -40,7 +40,7 @@ class HelpMessageExtension extends AbstractTypeExtension
         return self::getExtendedTypes()[0];
     }
 
-    public static function getExtendedTypes()
+    public static function getExtendedTypes(): iterable
     {
         return ['Symfony\Component\Form\Extension\Core\Type\FormType'];
     }

--- a/Form/Extension/NoValidateExtension.php
+++ b/Form/Extension/NoValidateExtension.php
@@ -41,7 +41,7 @@ class NoValidateExtension extends AbstractTypeExtension
         return self::getExtendedTypes()[0];
     }
 
-    public static function getExtendedTypes()
+    public static function getExtendedTypes(): iterable
     {
         return ['Symfony\Component\Form\Extension\Core\Type\FormType'];
     }

--- a/Form/Extension/SingleUploadExtension.php
+++ b/Form/Extension/SingleUploadExtension.php
@@ -32,7 +32,7 @@ class SingleUploadExtension extends AbstractTypeExtension
         return self::getExtendedTypes()[0];
     }
 
-    public static function getExtendedTypes()
+    public static function getExtendedTypes(): iterable
     {
         return ['Symfony\Component\Form\Extension\Core\Type\FormType'];
     }


### PR DESCRIPTION
Needed for Symfony 5 compatibility, but not sure if it breaks at SF4 or lower